### PR TITLE
Remove env reference and default secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@
 ]
 ```
 
+- add the mailgun api key to your `config/service.php` file
+```
+'mailgun' => [
+    'domain' => env('MAILGUN_DOMAIN'),
+    'secret' => env('MAILGUN_SECRET'),
+    'key' => env('MAILGUN_KEY'),
+],
+```
+
 ## Usage
 
 - add the rule to the validator

--- a/src/MailGunValidatorServiceProvider.php
+++ b/src/MailGunValidatorServiceProvider.php
@@ -17,7 +17,7 @@ class MailGunValidatorServiceProvider extends ServiceProvider
             $req = (new Client())->get('https://api.mailgun.net/v3/address/validate', [
                 'query' => [
                     'address' => $value,
-                    'api_key' => env('MAILGUN_API_KEY', 'pubkey-83a6-sl6j2m3daneyobi87b3-ksx3q29'),
+                    'api_key' => config('services.mailgun.key'),
                 ],
                 'auth'   => null,
             ]);


### PR DESCRIPTION
Removed the direct reference to the API key in the provider, and moved it to a config variable. The default key was also the creator's key I suppose, and that's not necessary. Users should just create their own MG account.